### PR TITLE
Write the corrected name for unnamed enums

### DIFF
--- a/Source/PDBHeaderReconstructor.cpp
+++ b/Source/PDBHeaderReconstructor.cpp
@@ -118,10 +118,7 @@ PDBHeaderReconstructor::OnEnumTypeBegin(
 
 	Write("enum");
 
-	if (!PDB::IsUnnamedSymbol(Symbol))
-	{
-		Write(" %s", CorrectedName.c_str());
-	}
+	Write(" %s", CorrectedName.c_str());
 
 	Write("\n");
 


### PR DESCRIPTION
The produced header was invalid when i ran it against a windows 10 ntoskrnl pdb, the PDB contained an unnamed enum which did not have a base typedef
typedef enum /*_TAG_UNNAMED_1 WAS MISSING*/
{
  KTMOH_CommitTransaction_Result = 1,
  KTMOH_RollbackTransaction_Result = 2,
} TAG_UNNAMED_1, *PTAG_UNNAMED_1;

Resulting in the following struct:
typedef struct _KTRANSACTION_HISTORY
{
  /* 0x0000 */ enum _TAG_UNNAMED_1 RecordType;
  /* 0x0004 */ uint32_t Payload;
} KTRANSACTION_HISTORY, *PKTRANSACTION_HISTORY; /* size: 0x0008 */

to fail the compilation.
