### PR TITLE
fix incorrect result of SymbolModuleBase::LoadDiaViaLoadLibrary

### DIFF
--- a/Source/PDB.cpp
+++ b/Source/PDB.cpp
@@ -74,7 +74,7 @@ SymbolModuleBase::LoadDiaViaLoadLibrary()
 	if (!Module)
 	{
 		Result = HRESULT_FROM_WIN32(GetLastError());
-		return FALSE;
+		return Result;
 	}
 
 	using PDLLGETCLASSOBJECT_ROUTINE = HRESULT(WINAPI*)(REFCLSID, REFIID, LPVOID);
@@ -83,7 +83,7 @@ SymbolModuleBase::LoadDiaViaLoadLibrary()
 	if (!DllGetClassObject)
 	{
 		Result = HRESULT_FROM_WIN32(GetLastError());
-		return FALSE;
+		return Result;
 	}
 
 	CComPtr<IClassFactory> ClassFactory;
@@ -91,7 +91,7 @@ SymbolModuleBase::LoadDiaViaLoadLibrary()
 
 	if (FAILED(Result))
 	{
-		return FALSE;
+		return Result;
 	}
 
 	return ClassFactory->CreateInstance(nullptr, __uuidof(IDiaDataSource), (void**)& m_DataSource);


### PR DESCRIPTION
This fixes pdbex crash - If dll not exist or has wrong architecture the LoadDiaViaLoadLibrary code will produce incorrect result and pass error checking, later this will crash pdbex as invalid memory (NULL) will be dereferenced.

This should fix 
#7 
#11 
#17 