### PR TITLE
Fix crash with newer Windows PDBs, add char8_t support

### DIFF
--- a/Source/PDB.cpp
+++ b/Source/PDB.cpp
@@ -1013,6 +1013,7 @@ BasicTypeMapElement BasicTypeMapStdInt[] = {
 	{ btNoType,       0,  "btNoType",         nullptr            },
 	{ btVoid,         0,  "btVoid",           "void"             },
 	{ btChar,         1,  "btChar",           "char"             },
+	{ btChar8,        1,  "btChar8",          "char8_t"          },
 	{ btChar16,       2,  "btChar16",         "char16_t"         },
 	{ btChar32,       4,  "btChar32",         "char32_t"         },
 	{ btWChar,        2,  "btWChar",          "wchar_t"          },
@@ -1040,7 +1041,6 @@ BasicTypeMapElement BasicTypeMapStdInt[] = {
 	{ btBit,          0,  "btBit",            nullptr            },
 	{ btBSTR,         0,  "btBSTR",           "BSTR"             },
 	{ btHresult,      4,  "btHresult",        "HRESULT"          },
-	{ btChar8,        1,  "btChar8",          "char8_t"          },
 	{ (BasicType)0,   0,  nullptr,            nullptr            },
 };
 

--- a/Source/PDB.cpp
+++ b/Source/PDB.cpp
@@ -1005,6 +1005,7 @@ BasicTypeMapElement BasicTypeMapMSVC[] = {
 	{ btBit,          0,  "btBit",            nullptr            },
 	{ btBSTR,         0,  "btBSTR",           "BSTR"             },
 	{ btHresult,      4,  "btHresult",        "HRESULT"          },
+	{ btChar8,        1,  "btChar8",          "char8_t"          },
 	{ (BasicType)0,   0,  nullptr,            nullptr            },
 };
 
@@ -1039,6 +1040,7 @@ BasicTypeMapElement BasicTypeMapStdInt[] = {
 	{ btBit,          0,  "btBit",            nullptr            },
 	{ btBSTR,         0,  "btBSTR",           "BSTR"             },
 	{ btHresult,      4,  "btHresult",        "HRESULT"          },
+	{ btChar8,        1,  "btChar8",          "char8_t"          },
 	{ (BasicType)0,   0,  nullptr,            nullptr            },
 };
 

--- a/Source/UdtFieldDefinition.h
+++ b/Source/UdtFieldDefinition.h
@@ -37,7 +37,13 @@ class UdtFieldDefinition
 				m_TypePrefix += "volatile ";
 			}
 
-			m_TypePrefix += PDB::GetBasicTypeString(Symbol, m_Settings->UseStdInt);
+			//
+			// If this returns null, it probably means BasicTypeMapMSVC and/or BasicTypeMapStdInt are out of date compared to MS DIA.
+			// Output the (non-compilable) type "<unknown_type>" instead of crashing.
+			//
+
+			const CHAR* BasicTypeString = PDB::GetBasicTypeString(Symbol, m_Settings->UseStdInt);
+			m_TypePrefix += (BasicTypeString != nullptr ? BasicTypeString : "<unknown_type>");
 		}
 
 		void


### PR DESCRIPTION
Some of the more recent Windows PDBs use `char8_t`, which a type that is in the current (VS 19.10) MS DIA SDK, but is not in the known type maps for pdbex. This causes a crash due to a nullptr dereference in `UdtFieldDefinition::VisitBaseType` (there was already an issue for this - see #12).

This is an input command that caused pdbex to crash for me (most arguments probably unnecessary):
`pdbex * WinTypes.pdb -o WinTypes.h -d -e i -u _anon_union_ -s _anon_struct_ -m -b -p-`
where `WinTypes.pdb` is the PDB for `WinTypes.dll` 10.0.21390.1, found in `C:\Symbols\WinTypes.pdb\383E6861B516E717207B5610F6C0D2F91`.

The first commit in this PR fixes the nullptr dereference, should a new type be added to the MS DIA SDK again in future. The non-compilable string `<unknown_type>` will be printed instead.

The second commit adds the `char8_t` type to the known type maps so that pdbex knows about it. Example output from the same `WinTypes.pdb`, which looks correct to me:
```C++
struct std::_Codecvt_guard<char16_t,char8_t>
{
  /* 0x0000 */ const char16_t* const& _First1;
  /* 0x0008 */ const char16_t*& _Mid1;
  /* 0x0010 */ char8_t* const& _First2;
  /* 0x0018 */ char8_t*& _Mid2;
}; /* size: 0x0020 */
```