### PR TITLE
Fix enum sign-extension

### DIFF
--- a/Source/PDBHeaderReconstructor.cpp
+++ b/Source/PDBHeaderReconstructor.cpp
@@ -515,25 +515,25 @@ PDBHeaderReconstructor::WriteVariant(
 			break;
 
 		case VT_UI1:
-			Write("0x%x", (UINT)v->cVal);
+			Write("0x%x", (UINT)v->bVal);
 			break;
 
 		case VT_I2:
-			Write("%d", (UINT)v->iVal);
+			Write("%d", (INT)v->iVal);
 			break;
 
 		case VT_UI2:
-			Write("0x%x", (UINT)v->iVal);
+			Write("0x%x", (UINT)v->uiVal);
 			break;
 
 		case VT_INT:
 		case VT_I4:
-			Write("%d", (UINT)v->lVal);
+			Write("%d", (INT)v->lVal);
 			break;
 
 		case VT_UINT:
 		case VT_UI4:
-			Write("0x%x", (UINT)v->lVal);
+			Write("0x%x", (UINT)v->ulVal);
 			break;
 	}
 }


### PR DESCRIPTION
This pull request fixes a bug in reconstructing some values in enumerations. The switch-case branch that prints unsigned two-byte (`VT_UI2`) values used to misinterpret them as signed and, thus, sing-extending them before printing.

Here is an example of an incorrect output:
```c
enum tagCLSCTX
{
  // -- truncated --
  CLSCTX_RESERVED5 = 2048,
  CLSCTX_NO_CUSTOM_MARSHAL = 4096,
  CLSCTX_ENABLE_CODE_DOWNLOAD = 8192,
  CLSCTX_NO_FAILURE_LOG = 16384,
  CLSCTX_DISABLE_AAA = 0xffff8000, // <--- should be 0x8000 instead
  CLSCTX_ENABLE_AAA = 0x10000,
  CLSCTX_FROM_DEFAULT_CONTEXT = 0x20000,
  // -- truncated --
};
```

The PR adjusts the code to access the correct variant fields.